### PR TITLE
Implement password hashing and token generation utilities

### DIFF
--- a/server/utils/bcrypt.ts
+++ b/server/utils/bcrypt.ts
@@ -6,6 +6,9 @@ export const hashPassword = async (password: string): Promise<string> => {
   return bcrypt.hash(password, SALT_ROUNDS);
 };
 
-export const comparePassword = async (password: string, hash: string): Promise<boolean> => {
+export const verifyPassword = async (
+  password: string,
+  hash: string
+): Promise<boolean> => {
   return bcrypt.compare(password, hash);
 };

--- a/server/utils/jwt.ts
+++ b/server/utils/jwt.ts
@@ -1,9 +1,12 @@
 import jwt from 'jsonwebtoken';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
-const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'your-refresh-secret-key';
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
-const JWT_REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN || '7d';
+const JWT_REFRESH_SECRET =
+  process.env.JWT_REFRESH_SECRET || 'your-refresh-secret-key';
+// Access tokens default to one day and refresh tokens to seven days
+const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '1d';
+const JWT_REFRESH_EXPIRES_IN =
+  process.env.JWT_REFRESH_EXPIRES_IN || '7d';
 
 export interface TokenPayload {
   userId: number;
@@ -34,7 +37,7 @@ export const verifyRefreshToken = (token: string): TokenPayload => {
   return jwt.verify(token, JWT_REFRESH_SECRET) as TokenPayload;
 };
 
-export const generateTokenPair = (payload: TokenPayload) => {
+export const generateTokens = (payload: TokenPayload) => {
   return {
     accessToken: generateAccessToken(payload),
     refreshToken: generateRefreshToken(payload)


### PR DESCRIPTION
## Summary
- Rename password helper to `verifyPassword` and keep hashing via bcrypt with 12 salt rounds
- Consolidate JWT handling with `generateTokens` and 1-day access token expiry
- Update authentication service to leverage new utilities for secure login and refresh

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68a1c3da7b888329b1ab35c8cd33b18b