### PR TITLE
feat: add automated MySQL schema checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
 
-    "schema:verify": "ts-node server/db/verifySchema.ts",
+    "schema:verify": "tsx server/db/verifySchema.ts",
+    "schema:check": "tsx server/db/checks/runSchemaCheck.ts",
 
     "docs:serve": "node server/docs/swagger.js"
   },

--- a/server/db/checks/README.md
+++ b/server/db/checks/README.md
@@ -1,0 +1,11 @@
+# Schema Checks
+
+This folder provides automated verification of the MySQL schema against the project specification.
+
+## Usage
+1. Set environment variables `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` to point to the read-only database.
+2. Run `npm run schema:check` from the repository root.
+3. Reports are generated in `server/db/checks/schema_report.json` and `server/db/checks/schema_report.md`.
+4. Raw snapshots for each table are saved under `server/db/checks/snapshots/`.
+
+The script performs only read operations and does not alter the database.

--- a/server/db/checks/expectedSchema.ts
+++ b/server/db/checks/expectedSchema.ts
@@ -1,0 +1,418 @@
+import type { } from 'mysql2';
+
+export interface ColumnSpec {
+  type: string;
+  nullable: boolean;
+  default?: string | null;
+  onUpdate?: string | null;
+  pk?: boolean;
+  unique?: boolean;
+  fk?: { table: string; column: string; onDelete?: string };
+}
+
+export interface TableSpec {
+  columns: Record<string, ColumnSpec>;
+  constraints?: {
+    unique?: Array<{ columns: string[]; name?: string }>;
+    fk?: Array<{ columns: string[]; referencedTable: string; referencedColumns: string[]; onDelete?: string }>;
+  };
+}
+
+export const expectedSchema: Record<string, TableSpec> = {
+  users: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      first_name: { type: 'VARCHAR(50)', nullable: false },
+      last_name: { type: 'VARCHAR(50)', nullable: false },
+      email: { type: 'VARCHAR(100)', nullable: false, unique: true },
+      phone: { type: 'VARCHAR(20)', nullable: true },
+      age: { type: 'INT', nullable: true },
+      password_hash: { type: 'VARCHAR(255)', nullable: false },
+      avatar_url: { type: 'VARCHAR(500)', nullable: true },
+      role: { type: "ENUM('student','instructor','admin')", nullable: false, default: "'student'" },
+      is_verified: { type: 'BOOLEAN', nullable: false, default: '0' },
+      email_verification_token: { type: 'VARCHAR(255)', nullable: true },
+      password_reset_token: { type: 'VARCHAR(255)', nullable: true },
+      password_reset_expires: { type: 'DATETIME', nullable: true },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      updated_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  user_profiles: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      bio: { type: 'TEXT', nullable: true },
+      linkedin_url: { type: 'VARCHAR(500)', nullable: true },
+      github_url: { type: 'VARCHAR(500)', nullable: true },
+      skills: { type: 'JSON', nullable: true },
+      experience_level: { type: "ENUM('beginner','intermediate','advanced')", nullable: true }
+    }
+  },
+  categories: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      name: { type: 'VARCHAR(100)', nullable: false, unique: true },
+      description: { type: 'TEXT', nullable: true },
+      icon: { type: 'VARCHAR(50)', nullable: true },
+      color: { type: 'VARCHAR(7)', nullable: true },
+      is_active: { type: 'BOOLEAN', nullable: false, default: '1' },
+      sort_order: { type: 'INT', nullable: true, default: '0' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  instructors: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      title: { type: 'VARCHAR(100)', nullable: true },
+      experience_years: { type: 'INT', nullable: true },
+      total_students: { type: 'INT', nullable: false, default: '0' },
+      total_courses: { type: 'INT', nullable: false, default: '0' },
+      rating: { type: 'DECIMAL(3,2)', nullable: false, default: '5.00' },
+      bio: { type: 'TEXT', nullable: true },
+      expertise: { type: 'JSON', nullable: true },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  courses: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      title: { type: 'VARCHAR(200)', nullable: false },
+      slug: { type: 'VARCHAR(250)', nullable: false, unique: true },
+      description: { type: 'TEXT', nullable: false },
+      category_id: { type: 'INT', nullable: false, fk: { table: 'categories', column: 'id' } },
+      instructor_id: { type: 'INT', nullable: false, fk: { table: 'instructors', column: 'id' } },
+      image_url: { type: 'VARCHAR(500)', nullable: true },
+      trailer_video_url: { type: 'VARCHAR(500)', nullable: true },
+      level: { type: "ENUM('beginner','intermediate','advanced')", nullable: false },
+      duration: { type: 'DECIMAL(5,2)', nullable: true },
+      language: { type: "ENUM('English','Français','Arabic')", nullable: false, default: "'English'" },
+      requirements: { type: 'JSON', nullable: true },
+      learning_objectives: { type: 'JSON', nullable: true },
+      tags: { type: 'JSON', nullable: true },
+      rating: { type: 'DECIMAL(3,2)', nullable: false, default: '0.00' },
+      student_count: { type: 'INT', nullable: false, default: '0' },
+      is_certified: { type: 'BOOLEAN', nullable: false, default: '1' },
+      last_updated: { type: 'DATE', nullable: true },
+      is_published: { type: 'BOOLEAN', nullable: false, default: '0' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      updated_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  course_pricing: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      course_id: { type: 'INT', nullable: false, fk: { table: 'courses', column: 'id', onDelete: 'CASCADE' } },
+      tier: { type: "ENUM('basic','pro','premium')", nullable: false },
+      price: { type: 'DECIMAL(10,2)', nullable: false },
+      original_price: { type: 'DECIMAL(10,2)', nullable: true },
+      features: { type: 'JSON', nullable: true },
+      is_active: { type: 'BOOLEAN', nullable: false, default: '1' }
+    },
+    constraints: {
+      unique: [ { columns: ['course_id', 'tier'], name: 'unique_course_tier' } ]
+    }
+  },
+  chapters: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      course_id: { type: 'INT', nullable: false, fk: { table: 'courses', column: 'id', onDelete: 'CASCADE' } },
+      title: { type: 'VARCHAR(200)', nullable: false },
+      description: { type: 'TEXT', nullable: true },
+      sort_order: { type: 'INT', nullable: false },
+      estimated_duration_minutes: { type: 'INT', nullable: true },
+      is_locked: { type: 'BOOLEAN', nullable: false, default: '1' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  lessons: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      chapter_id: { type: 'INT', nullable: false, fk: { table: 'chapters', column: 'id', onDelete: 'CASCADE' } },
+      title: { type: 'VARCHAR(200)', nullable: false },
+      description: { type: 'TEXT', nullable: true },
+      type: { type: "ENUM('video','project')", nullable: false },
+      video_url: { type: 'VARCHAR(500)', nullable: true },
+      presentation_url: { type: 'VARCHAR(500)', nullable: true },
+      overview: { type: 'LONGTEXT', nullable: false },
+      sort_order: { type: 'INT', nullable: false },
+      is_preview: { type: 'BOOLEAN', nullable: false, default: '0' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  exercises: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      lesson_id: { type: 'INT', nullable: false, fk: { table: 'lessons', column: 'id', onDelete: 'CASCADE' } },
+      title: { type: 'VARCHAR(200)', nullable: false },
+      description: { type: 'TEXT', nullable: false },
+      instructions: { type: 'JSON', nullable: true },
+      is_complete: { type: 'BOOLEAN', nullable: false, default: '0' }
+    }
+  },
+  quizzes: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      chapter_id: { type: 'INT', nullable: true, fk: { table: 'chapters', column: 'id', onDelete: 'CASCADE' } },
+      title: { type: 'VARCHAR(200)', nullable: false },
+      questions: { type: 'JSON', nullable: false },
+      passing_score: { type: 'INT', nullable: false, default: '80' },
+      time_limit_minutes: { type: 'INT', nullable: false, default: '15' },
+      attempts_allowed: { type: 'INT', nullable: false, default: '3' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  user_course_progress: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      course_id: { type: 'INT', nullable: false, fk: { table: 'courses', column: 'id', onDelete: 'CASCADE' } },
+      enrollment_date: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      completion_date: { type: 'TIMESTAMP', nullable: true },
+      progress_percentage: { type: 'DECIMAL(5,2)', nullable: false, default: '0.00' },
+      last_accessed: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' },
+      pricing_tier: { type: "ENUM('basic','pro','premium')", nullable: false },
+      status: { type: "ENUM('enrolled','completed','dropped')", nullable: false, default: "'enrolled'" }
+    },
+    constraints: {
+      unique: [ { columns: ['user_id', 'course_id'], name: 'unique_user_course' } ]
+    }
+  },
+  user_lesson_progress: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      lesson_id: { type: 'INT', nullable: false, fk: { table: 'lessons', column: 'id', onDelete: 'CASCADE' } },
+      is_completed: { type: 'BOOLEAN', nullable: false, default: '0' },
+      completion_date: { type: 'TIMESTAMP', nullable: true },
+      watch_time_seconds: { type: 'INT', nullable: false, default: '0' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      updated_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' }
+    },
+    constraints: {
+      unique: [ { columns: ['user_id', 'lesson_id'], name: 'unique_user_lesson' } ]
+    }
+  },
+  quiz_attempts: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      quiz_id: { type: 'INT', nullable: false, fk: { table: 'quizzes', column: 'id', onDelete: 'CASCADE' } },
+      score: { type: 'DECIMAL(5,2)', nullable: true },
+      answers: { type: 'JSON', nullable: true },
+      started_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      completed_at: { type: 'TIMESTAMP', nullable: true },
+      time_taken_minutes: { type: 'INT', nullable: true },
+      is_passed: { type: 'BOOLEAN', nullable: false, default: '0' },
+      attempt_number: { type: 'INT', nullable: false, default: '1' }
+    }
+  },
+  exams: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      course_id: { type: 'INT', nullable: false, fk: { table: 'courses', column: 'id', onDelete: 'CASCADE' } },
+      title: { type: 'VARCHAR(200)', nullable: false },
+      description: { type: 'TEXT', nullable: true },
+      instructions: { type: 'JSON', nullable: true },
+      requirements: { type: 'JSON', nullable: true },
+      duration_hours: { type: 'INT', nullable: false },
+      total_marks: { type: 'INT', nullable: false, default: '100' },
+      passing_marks: { type: 'INT', nullable: false, default: '70' },
+      attempts_limit: { type: 'INT', nullable: false, default: '3' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  exam_resources: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      exam_id: { type: 'INT', nullable: false, fk: { table: 'exams', column: 'id', onDelete: 'CASCADE' } },
+      file_name: { type: 'VARCHAR(200)', nullable: false },
+      file_description: { type: 'TEXT', nullable: false },
+      file_type: { type: 'VARCHAR(200)', nullable: false },
+      file_url: { type: 'VARCHAR(200)', nullable: false }
+    }
+  },
+  exam_submissions: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      exam_id: { type: 'INT', nullable: false, fk: { table: 'exams', column: 'id', onDelete: 'CASCADE' } },
+      submission_notes: { type: 'TEXT', nullable: true },
+      started_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      submitted_at: { type: 'TIMESTAMP', nullable: true },
+      graded_at: { type: 'TIMESTAMP', nullable: true },
+      score: { type: 'DECIMAL(5,2)', nullable: true },
+      feedback: { type: 'TEXT', nullable: true },
+      status: { type: "ENUM('in progress','submitted','graded','revision_required')", nullable: false, default: "'in progress'" },
+      attempt_number: { type: 'INT', nullable: false, default: '1' }
+    }
+  },
+  exam_submission_files: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      submission_id: { type: 'INT', nullable: false, fk: { table: 'exam_submissions', column: 'id', onDelete: 'CASCADE' } },
+      file_name: { type: 'VARCHAR(100)', nullable: false },
+      file_type: { type: 'VARCHAR(100)', nullable: false },
+      file_url: { type: 'VARCHAR(200)', nullable: false }
+    }
+  },
+  cart_items: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      course_id: { type: 'INT', nullable: false, fk: { table: 'courses', column: 'id', onDelete: 'CASCADE' } },
+      pricing_tier: { type: "ENUM('basic','pro','premium')", nullable: false },
+      base_price: { type: 'DECIMAL(10,2)', nullable: false },
+      added_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    },
+    constraints: {
+      unique: [ { columns: ['user_id', 'course_id'], name: 'unique_user_course_cart' } ]
+    }
+  },
+  orders: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      order_number: { type: 'VARCHAR(50)', nullable: false, unique: true },
+      total_amount: { type: 'DECIMAL(10,2)', nullable: false },
+      payment_status: { type: "ENUM('pending','completed','failed','refunded')", nullable: false, default: "'pending'" },
+      payment_method: { type: 'VARCHAR(50)', nullable: true },
+      payment_transaction_id: { type: 'VARCHAR(255)', nullable: true },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      updated_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  order_items: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      order_id: { type: 'INT', nullable: false, fk: { table: 'orders', column: 'id', onDelete: 'CASCADE' } },
+      course_id: { type: 'INT', nullable: false, fk: { table: 'courses', column: 'id' } },
+      pricing_tier: { type: "ENUM('basic','pro','premium')", nullable: false },
+      base_price: { type: 'DECIMAL(10,2)', nullable: false }
+    }
+  },
+  coupons: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      code: { type: 'VARCHAR(50)', nullable: false, unique: true },
+      description: { type: 'VARCHAR(200)', nullable: true },
+      discount_type: { type: "ENUM('percentage','fixed')", nullable: false },
+      discount_value: { type: 'DECIMAL(10,2)', nullable: false },
+      usage_limit: { type: 'INT', nullable: true },
+      used_count: { type: 'INT', nullable: false, default: '0' },
+      valid_from: { type: 'DATETIME', nullable: false },
+      valid_until: { type: 'DATETIME', nullable: false },
+      is_active: { type: 'BOOLEAN', nullable: false, default: '1' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  coupon_usage: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      coupon_id: { type: 'INT', nullable: false, fk: { table: 'coupons', column: 'id' } },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id' } },
+      order_id: { type: 'INT', nullable: false, fk: { table: 'orders', column: 'id' } },
+      discount_amount: { type: 'DECIMAL(10,2)', nullable: false },
+      used_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  blog_posts: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      author_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'SET NULL' } },
+      title: { type: 'VARCHAR(200)', nullable: false },
+      slug: { type: 'VARCHAR(250)', nullable: false, unique: true },
+      description: { type: 'TEXT', nullable: true },
+      content: { type: 'LONGTEXT', nullable: false },
+      featured_image: { type: 'VARCHAR(500)', nullable: true },
+      category: { type: 'VARCHAR(100)', nullable: true },
+      tags: { type: 'JSON', nullable: true },
+      view_count: { type: 'INT', nullable: false, default: '0' },
+      is_published: { type: 'BOOLEAN', nullable: false, default: '0' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      updated_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  testimonials: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id' } },
+      course_id: { type: 'INT', nullable: true, fk: { table: 'courses', column: 'id' } },
+      name: { type: 'VARCHAR(100)', nullable: false },
+      role: { type: 'VARCHAR(100)', nullable: true },
+      content: { type: 'TEXT', nullable: false },
+      rating: { type: 'DECIMAL(3,2)', nullable: false },
+      image_url: { type: 'VARCHAR(500)', nullable: true },
+      is_approved: { type: 'BOOLEAN', nullable: false, default: '0' },
+      is_featured: { type: 'BOOLEAN', nullable: false, default: '0' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  newsletter_subscribers: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      email: { type: 'VARCHAR(100)', nullable: false, unique: true },
+      name: { type: 'VARCHAR(100)', nullable: true },
+      is_subscribed: { type: 'BOOLEAN', nullable: false, default: '1' },
+      subscribed_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      unsubscribed_at: { type: 'TIMESTAMP', nullable: true },
+      verification_token: { type: 'VARCHAR(255)', nullable: true },
+      is_verified: { type: 'BOOLEAN', nullable: false, default: '0' }
+    }
+  },
+  course_reviews: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      course_id: { type: 'INT', nullable: false, fk: { table: 'courses', column: 'id', onDelete: 'CASCADE' } },
+      rating: { type: 'DECIMAL(3,2)', nullable: false },
+      review_text: { type: 'TEXT', nullable: true },
+      is_approved: { type: 'BOOLEAN', nullable: false, default: '0' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' },
+      updated_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' }
+    },
+    constraints: {
+      unique: [ { columns: ['user_id', 'course_id'], name: 'unique_user_course_review' } ]
+    }
+  },
+  certificates: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      course_id: { type: 'INT', nullable: false, fk: { table: 'courses', column: 'id', onDelete: 'CASCADE' } },
+      certificate_number: { type: 'VARCHAR(100)', nullable: false, unique: true },
+      issued_date: { type: 'DATE', nullable: false },
+      certificate_url: { type: 'VARCHAR(500)', nullable: true },
+      verification_code: { type: 'VARCHAR(100)', nullable: true, unique: true },
+      is_valid: { type: 'BOOLEAN', nullable: false, default: '1' },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  notifications: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      user_id: { type: 'INT', nullable: false, fk: { table: 'users', column: 'id', onDelete: 'CASCADE' } },
+      title: { type: 'VARCHAR(200)', nullable: false },
+      message: { type: 'TEXT', nullable: false },
+      type: { type: "ENUM('info','success','warning','error')", nullable: false, default: "'info'" },
+      category: { type: "ENUM('course','payment','system','marketing')", nullable: false, default: "'system'" },
+      is_read: { type: 'BOOLEAN', nullable: false, default: '0' },
+      action_url: { type: 'VARCHAR(500)', nullable: true },
+      created_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  },
+  email_logs: {
+    columns: {
+      id: { type: 'INT', nullable: false, pk: true },
+      recipient_email: { type: 'VARCHAR(100)', nullable: false },
+      subject: { type: 'VARCHAR(200)', nullable: false },
+      template_name: { type: 'VARCHAR(100)', nullable: true },
+      status: { type: "ENUM('sent','failed','bounced')", nullable: false, default: "'sent'" },
+      error_message: { type: 'TEXT', nullable: true },
+      sent_at: { type: 'TIMESTAMP', nullable: false, default: 'CURRENT_TIMESTAMP' }
+    }
+  }
+};
+
+export default expectedSchema;

--- a/server/db/checks/runSchemaCheck.ts
+++ b/server/db/checks/runSchemaCheck.ts
@@ -1,0 +1,282 @@
+// AUDIT:Database Schema -> automated evidence generation
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import mysql from 'mysql2/promise';
+import 'dotenv/config';
+import expectedSchema from './expectedSchema.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const snapshotsDir = path.resolve(__dirname, 'snapshots');
+
+interface ColumnRow {
+  COLUMN_NAME: string;
+  COLUMN_TYPE: string;
+  IS_NULLABLE: string;
+  COLUMN_DEFAULT: any;
+  EXTRA: string;
+}
+
+interface ConstraintData {
+  primaryKeys: string[];
+  uniqueKeys: Array<{ name: string; columns: string[] }>;
+  foreignKeys: Array<{ name: string; columns: string[]; referencedTable: string; referencedColumns: string[]; deleteRule?: string }>;
+}
+
+interface TableReport {
+  status: 'OK' | 'PARTIEL' | 'NON';
+  differences: string[];
+  evidence?: { create: { path: string; lines: number }; columns: string; constraints: string };
+  error?: string;
+}
+
+function normType(t: string) {
+  return t.toLowerCase().replace('boolean', 'tinyint(1)');
+}
+
+function compareSets(a: string[], b: string[]) {
+  if (a.length !== b.length) return false;
+  const as = [...a].sort().join(',');
+  const bs = [...b].sort().join(',');
+  return as === bs;
+}
+
+async function fetchConstraints(conn: mysql.Connection, db: string, table: string): Promise<ConstraintData> {
+  const [rows] = await conn.query<any>(
+    `SELECT tc.CONSTRAINT_NAME, tc.CONSTRAINT_TYPE, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, rc.DELETE_RULE
+     FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+     JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA AND tc.TABLE_NAME = kcu.TABLE_NAME
+     LEFT JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc ON tc.CONSTRAINT_NAME = rc.CONSTRAINT_NAME AND tc.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+     WHERE tc.TABLE_SCHEMA = ? AND tc.TABLE_NAME = ?
+     ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION`,
+    [db, table]
+  );
+
+  const data: ConstraintData = { primaryKeys: [], uniqueKeys: [], foreignKeys: [] };
+  const grouped: Record<string, any[]> = {};
+  for (const r of rows) {
+    if (!grouped[r.CONSTRAINT_NAME]) grouped[r.CONSTRAINT_NAME] = [];
+    grouped[r.CONSTRAINT_NAME].push(r);
+  }
+  for (const [name, group] of Object.entries(grouped)) {
+    const type = group[0].CONSTRAINT_TYPE as string;
+    const cols = group.map(g => g.COLUMN_NAME);
+    if (type === 'PRIMARY KEY') {
+      data.primaryKeys.push(...cols);
+    } else if (type === 'UNIQUE') {
+      data.uniqueKeys.push({ name, columns: cols });
+    } else if (type === 'FOREIGN KEY') {
+      data.foreignKeys.push({ name, columns: cols, referencedTable: group[0].REFERENCED_TABLE_NAME, referencedColumns: group.map(g => g.REFERENCED_COLUMN_NAME), deleteRule: group[0].DELETE_RULE });
+    }
+  }
+  return data;
+}
+
+async function checkTable(conn: mysql.Connection, db: string, table: string, spec: any): Promise<TableReport> {
+  const [existsRows] = await conn.query<any>(
+    'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+    [db, table]
+  );
+  if (existsRows.length === 0) {
+    return { status: 'NON', differences: ['table not found'] };
+  }
+
+  const [colsRows] = await conn.query<ColumnRow[]>(
+    `SELECT COLUMN_NAME,COLUMN_TYPE,IS_NULLABLE,COLUMN_DEFAULT,EXTRA FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=? AND TABLE_NAME=? ORDER BY ORDINAL_POSITION`,
+    [db, table]
+  );
+  const constraints = await fetchConstraints(conn, db, table);
+  const [createRows] = await conn.query<any>(`SHOW CREATE TABLE \`${table}\``);
+  const createSQL: string = createRows[0]['Create Table'];
+
+  await fs.mkdir(snapshotsDir, { recursive: true });
+  const createPath = path.join(snapshotsDir, `${table}.create.sql`);
+  await fs.writeFile(createPath, createSQL + '\n');
+  const columnsPath = path.join(snapshotsDir, `${table}.columns.json`);
+  await fs.writeFile(columnsPath, JSON.stringify(colsRows, null, 2));
+  const constraintsPath = path.join(snapshotsDir, `${table}.constraints.json`);
+  await fs.writeFile(constraintsPath, JSON.stringify(constraints, null, 2));
+  const createLines = createSQL.split('\n').length;
+
+  const diffs: string[] = [];
+  const colMap: Record<string, ColumnRow> = {};
+  for (const c of colsRows) colMap[c.COLUMN_NAME] = c;
+
+  for (const [colName, colSpec] of Object.entries(spec.columns)) {
+    const actual = colMap[colName];
+    if (!actual) {
+      diffs.push(`missing column ${colName}`);
+      continue;
+    }
+    if (normType(actual.COLUMN_TYPE) !== normType(colSpec.type)) {
+      diffs.push(`type mismatch on ${colName}`);
+    }
+    const nullable = actual.IS_NULLABLE === 'YES';
+    if (nullable !== colSpec.nullable) {
+      diffs.push(`nullability mismatch on ${colName}`);
+    }
+    const actualDef = actual.COLUMN_DEFAULT === null ? null : String(actual.COLUMN_DEFAULT).toUpperCase();
+    const expectedDef = colSpec.default ? colSpec.default.toUpperCase() : null;
+    if (actualDef !== expectedDef) {
+      diffs.push(`default mismatch on ${colName}`);
+    }
+    const actualOnUpd = actual.EXTRA.toUpperCase().includes('ON UPDATE') ? 'CURRENT_TIMESTAMP' : null;
+    const expectedOnUpd = colSpec.onUpdate ? colSpec.onUpdate.toUpperCase() : null;
+    if (actualOnUpd !== expectedOnUpd) {
+      if (expectedOnUpd || actualOnUpd) diffs.push(`onUpdate mismatch on ${colName}`);
+    }
+    if (colSpec.pk) {
+      if (!constraints.primaryKeys.includes(colName)) diffs.push(`primary key missing on ${colName}`);
+    }
+    if (colSpec.unique) {
+      const hasUnique = constraints.uniqueKeys.some(u => u.columns.length === 1 && u.columns[0] === colName);
+      if (!hasUnique) diffs.push(`unique constraint missing on ${colName}`);
+    }
+    if (colSpec.fk) {
+      const fkFound = constraints.foreignKeys.some(fk => fk.columns.length === 1 && fk.columns[0] === colName && fk.referencedTable === colSpec.fk.table && fk.referencedColumns[0] === colSpec.fk.column && (!colSpec.fk.onDelete || fk.deleteRule === colSpec.fk.onDelete));
+      if (!fkFound) diffs.push(`foreign key mismatch on ${colName}`);
+    }
+  }
+
+  if (spec.constraints?.unique) {
+    for (const u of spec.constraints.unique) {
+      const found = constraints.uniqueKeys.some(act => compareSets(act.columns, u.columns));
+      if (!found) diffs.push(`missing unique constraint on (${u.columns.join(',')})`);
+    }
+  }
+
+  const status: TableReport['status'] = diffs.length === 0 ? 'OK' : 'PARTIEL';
+  return { status, differences: diffs, evidence: { create: { path: createPath, lines: createLines }, columns: columnsPath, constraints: constraintsPath } };
+}
+
+async function main() {
+  const tablesOrder = [
+    'users','user_profiles','categories','instructors','courses','course_pricing','chapters','lessons','exercises',
+    'quizzes','user_course_progress','user_lesson_progress','quiz_attempts','exams','exam_resources','exam_submissions','exam_submission_files',
+    'cart_items','orders','order_items','coupons','coupon_usage',
+    'blog_posts','testimonials','newsletter_subscribers','course_reviews',
+    'certificates','notifications','email_logs'
+  ];
+  const reports: Record<string, TableReport> = {};
+  try {
+    const conn = await mysql.createConnection({
+      host: process.env.DB_HOST,
+      port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME
+    });
+    const db = process.env.DB_NAME as string;
+    // AUDIT:Database Schema -> users
+    reports['users'] = await checkTable(conn, db, 'users', (expectedSchema as any)['users']);
+    // AUDIT:Database Schema -> user_profiles
+    reports['user_profiles'] = await checkTable(conn, db, 'user_profiles', (expectedSchema as any)['user_profiles']);
+    // AUDIT:Database Schema -> categories
+    reports['categories'] = await checkTable(conn, db, 'categories', (expectedSchema as any)['categories']);
+    // AUDIT:Database Schema -> instructors
+    reports['instructors'] = await checkTable(conn, db, 'instructors', (expectedSchema as any)['instructors']);
+    // AUDIT:Database Schema -> courses
+    reports['courses'] = await checkTable(conn, db, 'courses', (expectedSchema as any)['courses']);
+    // AUDIT:Database Schema -> course_pricing
+    reports['course_pricing'] = await checkTable(conn, db, 'course_pricing', (expectedSchema as any)['course_pricing']);
+    // AUDIT:Database Schema -> chapters
+    reports['chapters'] = await checkTable(conn, db, 'chapters', (expectedSchema as any)['chapters']);
+    // AUDIT:Database Schema -> lessons
+    reports['lessons'] = await checkTable(conn, db, 'lessons', (expectedSchema as any)['lessons']);
+    // AUDIT:Database Schema -> exercises
+    reports['exercises'] = await checkTable(conn, db, 'exercises', (expectedSchema as any)['exercises']);
+    // AUDIT:Database Schema -> quizzes
+    reports['quizzes'] = await checkTable(conn, db, 'quizzes', (expectedSchema as any)['quizzes']);
+    // AUDIT:Database Schema -> user_course_progress
+    reports['user_course_progress'] = await checkTable(conn, db, 'user_course_progress', (expectedSchema as any)['user_course_progress']);
+    // AUDIT:Database Schema -> user_lesson_progress
+    reports['user_lesson_progress'] = await checkTable(conn, db, 'user_lesson_progress', (expectedSchema as any)['user_lesson_progress']);
+    // AUDIT:Database Schema -> quiz_attempts
+    reports['quiz_attempts'] = await checkTable(conn, db, 'quiz_attempts', (expectedSchema as any)['quiz_attempts']);
+    // AUDIT:Database Schema -> exams
+    reports['exams'] = await checkTable(conn, db, 'exams', (expectedSchema as any)['exams']);
+    // AUDIT:Database Schema -> exam_resources
+    reports['exam_resources'] = await checkTable(conn, db, 'exam_resources', (expectedSchema as any)['exam_resources']);
+    // AUDIT:Database Schema -> exam_submissions
+    reports['exam_submissions'] = await checkTable(conn, db, 'exam_submissions', (expectedSchema as any)['exam_submissions']);
+    // AUDIT:Database Schema -> exam_submission_files
+    reports['exam_submission_files'] = await checkTable(conn, db, 'exam_submission_files', (expectedSchema as any)['exam_submission_files']);
+    // AUDIT:Database Schema -> cart_items
+    reports['cart_items'] = await checkTable(conn, db, 'cart_items', (expectedSchema as any)['cart_items']);
+    // AUDIT:Database Schema -> orders
+    reports['orders'] = await checkTable(conn, db, 'orders', (expectedSchema as any)['orders']);
+    // AUDIT:Database Schema -> order_items
+    reports['order_items'] = await checkTable(conn, db, 'order_items', (expectedSchema as any)['order_items']);
+    // AUDIT:Database Schema -> coupons
+    reports['coupons'] = await checkTable(conn, db, 'coupons', (expectedSchema as any)['coupons']);
+    // AUDIT:Database Schema -> coupon_usage
+    reports['coupon_usage'] = await checkTable(conn, db, 'coupon_usage', (expectedSchema as any)['coupon_usage']);
+    // AUDIT:Database Schema -> blog_posts
+    reports['blog_posts'] = await checkTable(conn, db, 'blog_posts', (expectedSchema as any)['blog_posts']);
+    // AUDIT:Database Schema -> testimonials
+    reports['testimonials'] = await checkTable(conn, db, 'testimonials', (expectedSchema as any)['testimonials']);
+    // AUDIT:Database Schema -> newsletter_subscribers
+    reports['newsletter_subscribers'] = await checkTable(conn, db, 'newsletter_subscribers', (expectedSchema as any)['newsletter_subscribers']);
+    // AUDIT:Database Schema -> course_reviews
+    reports['course_reviews'] = await checkTable(conn, db, 'course_reviews', (expectedSchema as any)['course_reviews']);
+    // AUDIT:Database Schema -> certificates
+    reports['certificates'] = await checkTable(conn, db, 'certificates', (expectedSchema as any)['certificates']);
+    // AUDIT:Database Schema -> notifications
+    reports['notifications'] = await checkTable(conn, db, 'notifications', (expectedSchema as any)['notifications']);
+    // AUDIT:Database Schema -> email_logs
+    reports['email_logs'] = await checkTable(conn, db, 'email_logs', (expectedSchema as any)['email_logs']);
+    await conn.end();
+  } catch (err: any) {
+    console.error('DB connection failed', err);
+    for (const table of tablesOrder) {
+      const msg = `erreur connexion DB: ${err.message || err.code || err}`;
+      reports[table] = { status: 'NON', differences: [], error: msg };
+    }
+  }
+
+  const summary = { OK: 0, PARTIEL: 0, NON: 0 } as Record<string, number>;
+  for (const r of Object.values(reports)) {
+    summary[r.status]++;
+  }
+  const jsonPath = path.resolve(__dirname, 'schema_report.json');
+  await fs.writeFile(jsonPath, JSON.stringify({ tables: reports, summary }, null, 2));
+
+  const mdPath = path.resolve(__dirname, 'schema_report.md');
+  const lines: string[] = ['# Database Schema Check — Evidence',''];
+  const sections: Record<string, string[]> = {
+    '## 3.1 User Management Tables': ['users','user_profiles'],
+    '## 3.2 Course Management Tables': ['categories','instructors','courses','course_pricing','chapters','lessons','exercises'],
+    '## 3.3 Assessment & Progress Tables': ['quizzes','user_course_progress','user_lesson_progress','quiz_attempts','exams','exam_resources','exam_submissions','exam_submission_files'],
+    '## 3.4 E-commerce Tables': ['cart_items','orders','order_items','coupons','coupon_usage'],
+    '## 3.5 Content Management Tables': ['blog_posts','testimonials','newsletter_subscribers','course_reviews'],
+    '## 3.6 Certificates and Notifications': ['certificates','notifications','email_logs']
+  };
+
+  for (const [section, tbls] of Object.entries(sections)) {
+    lines.push(section, '');
+    for (const t of tbls) {
+      const rep = reports[t];
+      lines.push(`${t.charAt(0).toUpperCase() + t.slice(1).replace(/_/g,' ')} table`);
+      lines.push('EXIGENCE : "Schéma conforme au cahier de charges"');
+      lines.push(`STATUT : ${rep.status}`);
+      if (rep.error) {
+        lines.push('PREUVES :');
+        lines.push(`- Artefacts : ${rep.error}`);
+      } else if (rep.evidence) {
+        lines.push('PREUVES :');
+        lines.push(`- Fichiers/Lignes : ${path.relative(path.resolve(""), rep.evidence.create.path)} (L1-L${rep.evidence.create.lines})`);
+        lines.push(`- Artefacts : ${path.relative(path.resolve(""), rep.evidence.columns)} ; ${path.relative(path.resolve(""), rep.evidence.constraints)}`);
+      }
+      lines.push('');
+    }
+  }
+  lines.push('Récapitulatif','');
+  lines.push(`OK : ${summary.OK}`);
+  lines.push(`PARTIEL : ${summary.PARTIEL}`);
+  lines.push(`NON : ${summary.NON}`);
+  await fs.writeFile(mdPath, lines.join('\n'));
+  console.log('Summary:', summary);
+}
+
+main();

--- a/server/db/checks/schema_report.json
+++ b/server/db/checks/schema_report.json
@@ -1,0 +1,154 @@
+{
+  "tables": {
+    "users": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "user_profiles": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "categories": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "instructors": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "courses": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "course_pricing": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "chapters": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "lessons": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "exercises": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "quizzes": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "user_course_progress": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "user_lesson_progress": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "quiz_attempts": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "exams": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "exam_resources": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "exam_submissions": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "exam_submission_files": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "cart_items": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "orders": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "order_items": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "coupons": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "coupon_usage": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "blog_posts": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "testimonials": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "newsletter_subscribers": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "course_reviews": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "certificates": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "notifications": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    },
+    "email_logs": {
+      "status": "NON",
+      "differences": [],
+      "error": "erreur connexion DB: ECONNREFUSED"
+    }
+  },
+  "summary": {
+    "OK": 0,
+    "PARTIEL": 0,
+    "NON": 29
+  }
+}

--- a/server/db/checks/schema_report.md
+++ b/server/db/checks/schema_report.md
@@ -1,0 +1,193 @@
+# Database Schema Check — Evidence
+
+## 3.1 User Management Tables
+
+Users table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+User profiles table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+## 3.2 Course Management Tables
+
+Categories table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Instructors table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Courses table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Course pricing table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Chapters table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Lessons table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Exercises table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+## 3.3 Assessment & Progress Tables
+
+Quizzes table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+User course progress table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+User lesson progress table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Quiz attempts table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Exams table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Exam resources table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Exam submissions table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Exam submission files table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+## 3.4 E-commerce Tables
+
+Cart items table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Orders table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Order items table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Coupons table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Coupon usage table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+## 3.5 Content Management Tables
+
+Blog posts table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Testimonials table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Newsletter subscribers table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Course reviews table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+## 3.6 Certificates and Notifications
+
+Certificates table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Notifications table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Email logs table
+EXIGENCE : "Schéma conforme au cahier de charges"
+STATUT : NON
+PREUVES :
+- Artefacts : erreur connexion DB: ECONNREFUSED
+
+Récapitulatif
+
+OK : 0
+PARTIEL : 0
+NON : 29


### PR DESCRIPTION
## Summary
- add expected schema definitions for all MySQL tables
- implement runSchemaCheck script to snapshot and compare database schema
- document usage and expose npm script

## Testing
- `npm run schema:check` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_b_68a1e8dd961883298e1e8cd283bf4ec3