### PR TITLE
fix(db): ensure esm imports and add connection test

### DIFF
--- a/server/db/checks/runSchemaCheck.ts
+++ b/server/db/checks/runSchemaCheck.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import mysql from 'mysql2/promise';
 import 'dotenv/config';
-import expectedSchema from './expectedSchema.ts';
+import expectedSchema from './expectedSchema.js';
 import { pool } from '../../db.js';
 
 

--- a/server/db/checks/testConnection.ts
+++ b/server/db/checks/testConnection.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function main() {
+  try {
+    const { pool } = await import(path.resolve(__dirname, '../../db.js'));
+    const conn = await pool.getConnection();
+    console.log('✅ Database connection successful!');
+    conn.release();
+    await pool.end();
+  } catch (err) {
+    console.error('❌ Database connection failed:', err);
+  }
+}
+
+main();

--- a/server/db/verifySchema.ts
+++ b/server/db/verifySchema.ts
@@ -1,4 +1,4 @@
-import { pool } from '../db.ts';
+import { pool } from '../db.js';
 
 // AUDIT:Database Schema -> schema evidence
 


### PR DESCRIPTION
## Summary
- fix database scripts to use .js extensions under ESM
- add a reusable testConnection script for verifying database connectivity

## Testing
- `npm run check` *(fails: Untyped function calls may not accept type arguments; ColumnRow[] errors, etc.)*
- `npx tsx server/db/checks/testConnection.ts` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_b_68a1f7bc24f88329baa63ffa51578837