### PR TITLE
Configure default sender email

### DIFF
--- a/.env
+++ b/.env
@@ -8,9 +8,10 @@ DB_NAME=easyways_skills
 
 SMTP_HOST=smtp.exemple.com
 SMTP_PORT=587
-SMTP_SECURE=false 
-SMTP_USER=utilisateur
+SMTP_SECURE=false
+SMTP_USER=skills@easyways.tn
 SMTP_PASS=motdepasse
+SMTP_FROM=skills@easyways.tn
 
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/server/services/email.service.ts
+++ b/server/services/email.service.ts
@@ -37,9 +37,13 @@ export const emailMetrics = {
 
 export async function sendEmail(options: SendMailOptions) {
   emailMetrics.attempts++;
+
+  const defaultFrom = process.env.SMTP_FROM || primary.auth.user;
+  const mailOptions: SendMailOptions = { from: defaultFrom, ...options };
+
   for (const transport of transports) {
     try {
-      const info = await transport.sendMail(options);
+      const info = await transport.sendMail(mailOptions);
       emailMetrics.successes++;
       return info;
     } catch (err) {


### PR DESCRIPTION
## Summary
- set `skills@easyways.tn` as the SMTP user and default from address
- ensure email service always includes a from address from configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in server/db and services)*

------
https://chatgpt.com/codex/tasks/task_b_68a2fcad4f608329a5300707a5801d64